### PR TITLE
Removed the support of writing async `__new__`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v3
         with:
-          submodules: true
-      - name: Setup Python ${{ matrix.python_version }}
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
+          version: '2.11.1'
           python-version: ${{ matrix.python_version }}
       - name: Setup tox
         run: pip install tox>=4.0

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "flake8", "format", "mypy", "test", "tox"]
+groups = ["default", "coverage", "dev", "flake8", "format", "mypy", "test", "tox"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:70ec6c17bc0059ab67c7987906d7d6497a215ca254a4c50919220aae20689d77"
+content_hash = "sha256:b9d961b12adf8a540a98275e8bc51a197ed985238927ed7f4872fb556a4933aa"
 
 [[package]]
 name = "black"
@@ -263,7 +263,7 @@ name = "coverage"
 version = "7.3.4"
 requires_python = ">=3.8"
 summary = "Code coverage measurement for Python"
-groups = ["test"]
+groups = ["coverage", "test"]
 files = [
     {file = "coverage-7.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aff2bd3d585969cc4486bfc69655e862028b689404563e6b549e6a8244f226df"},
     {file = "coverage-7.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4353923f38d752ecfbd3f1f20bf7a3546993ae5ecd7c07fd2f25d40b4e54571"},
@@ -315,7 +315,7 @@ version = "7.3.4"
 extras = ["toml"]
 requires_python = ">=3.8"
 summary = "Code coverage measurement for Python"
-groups = ["test"]
+groups = ["coverage", "test"]
 dependencies = [
     "coverage==7.3.4",
     "tomli; python_full_version <= \"3.11.0a6\"",
@@ -1062,7 +1062,7 @@ name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
 summary = "A lil' TOML parser"
-groups = ["dev", "format", "mypy", "test", "tox"]
+groups = ["coverage", "dev", "format", "mypy", "test", "tox"]
 marker = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
@@ -1119,7 +1119,7 @@ name = "typing-extensions"
 version = "4.9.0"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["default", "format", "mypy"]
+groups = ["format", "mypy", "test"]
 files = [
     {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
     {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ authors = [{name = "FrankySnow9", email = "clairicia.rcj.francis@gmail.com"}]
 requires-python = ">=3.9"
 readme = "README.md"
 license-files = { paths = ["LICENSE"] }
-dependencies = [
-    "typing-extensions>=4.9.0",
-]
+dependencies = []
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -74,6 +72,10 @@ test = [
     "pytest~=7.2",
     "pytest-asyncio~=0.20",
     "pytest-cov<5,>=4.0",
+    "coverage[toml]",
+    "typing-extensions>=4.9.0",
+]
+coverage = [
     "coverage[toml]",
 ]
 

--- a/src/async_object/contrib/mypy/plugin.py
+++ b/src/async_object/contrib/mypy/plugin.py
@@ -69,14 +69,12 @@ def async_class_instanciation_callback(ctx: FunctionContext) -> Type:
 def async_class_def_callback(ctx: ClassDefContext) -> None:
     info = ctx.cls.info
 
-    for ctor in ("__new__", "__init__"):
+    for ctor in {"__init__"}:
         node = info.names.get(ctor)
         if node is None or node.node is None:
             continue
 
-        new_ctor_name: str | None = None
-        if ctor in {"__init__"}:
-            new_ctor_name = f"__async_{ctor[2:-2]}_mypy_placeholder"
+        new_ctor_name = f"__async_{ctor[2:-2]}_mypy_placeholder"
 
         func_items: Sequence[SymbolNode]
         if isinstance(node.node, OverloadedFuncDef):
@@ -97,11 +95,9 @@ def async_class_def_callback(ctx: ClassDefContext) -> None:
                     code=errorcodes.OVERRIDE,
                 )
                 continue
-            if new_ctor_name is not None:
-                __set_func_def_name(defn, new_ctor_name)
+            __set_func_def_name(defn, new_ctor_name)
 
-        if new_ctor_name is not None:
-            info.names[new_ctor_name] = info.names[ctor]
+        info.names[new_ctor_name] = info.names[ctor]
 
     if info.get_method("__await__") is not None:
         ctx.api.fail('AsyncObject subclasses must not have "__await__" method', ctx.cls, code=errorcodes.OVERRIDE)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -58,8 +58,8 @@ async def test_subclass_with_arguments_for_dunder_new() -> None:
     class MyObject(AsyncObject):
         myattr_from_new: int
 
-        async def __new__(cls, value: int) -> Self:  # type: ignore[misc]
-            self = await super().__new__(cls)
+        def __new__(cls, value: int) -> Self:
+            self = super().__new__(cls)
             self.myattr_from_new = value
             return self
 
@@ -75,8 +75,8 @@ async def test_subclass_with_custom_dunder_new() -> None:
     # Arrange
 
     class MyObject(AsyncObject):
-        async def __new__(cls, value: int) -> Self:  # type: ignore[misc]
-            self = await super().__new__(cls)
+        def __new__(cls, value: int) -> Self:
+            self = super().__new__(cls)
             self.myattr_from_new = value * 2
             return self
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,18 @@
 minversion = 4.0
 envlist = py3{9,10,11,12}, coverage
 skip_missing_interpreters = true
+requires =
+    tox-pdm~=0.7.0
 
 [base]
 setenv =
     PYTHONHASHSEED = 100
+    PDM_IGNORE_SAVED_PYTHON = 1
+    PDM_CHECK_UPDATE = False
 
 [testenv:py3{9,10,11,12}]
-deps =
-    pytest>=7.2
-    pytest-cov>=4.0,<5
-    pytest-asyncio~=0.20
-    coverage[toml]  # Force install extra in order to use pyproject.toml as config file
+groups =
+    test
 setenv =
     {[base]setenv}
     COVERAGE_FILE=.coverage.{envname}
@@ -23,8 +24,8 @@ commands =
 skip_install = True
 depends = py3{9,10,11,12}
 parallel_show_output = True
-deps =
-    coverage[toml]
+groups =
+    coverage
 setenv =
     {[base]setenv}
     COVERAGE_FILE=.coverage


### PR DESCRIPTION
### Why remove `async def __new__`?
When I wrote the first version of this library, it was mostly to prove that something like this was possible. But in practical use:

1. There is no need to perform asynchronous operations on object allocation.
2. This can lead to confusion with other base classes.
3. It is hard to maintain such a feature that involves the creation of the object itself.